### PR TITLE
Allow handling of BN with trailing empty string arguments, but warn against using them

### DIFF
--- a/lib/Locale/Maketext/Utils/Phrase.pm
+++ b/lib/Locale/Maketext/Utils/Phrase.pm
@@ -8,10 +8,10 @@ use Module::Want ();
 
 $Locale::Maketext::Utils::Phrase::VERSION = '0.1';
 
-my $closing_bn = qr/(?<!\~)\]/;
-my $opening_bn = qr/(?<!\~)\[/;
-my $bn_delimit = qr/(?<!\~)\,/;
-my $bn_var_arg = qr/(?<!\~)\_(?:0|\-?[1-9]+[0-9]*|\*)/;
+our $closing_bn = qr/(?<!\~)\]/;
+our $opening_bn = qr/(?<!\~)\[/;
+our $bn_delimit = qr/(?<!\~)\,/;
+our $bn_var_arg = qr/(?<!\~)\_(?:0|\-?[1-9]+[0-9]*|\*)/;
 
 sub get_bn_var_regexp {
     return qr/(?<!\~)\_(?:0|\-?[1-9]+[0-9]*|\*)/;

--- a/lib/Locale/Maketext/Utils/Phrase.pm
+++ b/lib/Locale/Maketext/Utils/Phrase.pm
@@ -132,7 +132,7 @@ sub struct_is_entirely_bracket_notation {
 sub _split_bn_cont {
     my ( $cont, $limit ) = @_;
     $limit = abs( int( $limit || 0 ) );
-    return $limit ? split( $bn_delimit, $cont, $limit ) : split( $bn_delimit, $cont );
+    return $limit ? split( $bn_delimit, $cont, $limit ) : split( $bn_delimit, $cont, -1 );
 }
 
 my %meth = (

--- a/t/07.phrase_norm.t
+++ b/t/07.phrase_norm.t
@@ -1,4 +1,4 @@
-use Test::More tests => 618 + 1;
+use Test::More tests => 650 + 1;
 use Test::NoWarnings;    # + 1
 
 BEGIN {
@@ -405,6 +405,31 @@ run_32_tests(
 }
 
 # /32k more }
+
+# empty string arguments to complex BN expressions
+
+run_32_tests(
+    'filter_name'    => 'Consider',
+    'filter_pos'     => 8,
+    'original'       => 'X [boolean,_1,true,false] [boolean,_2,true,] [boolean,_3,,false] [boolean,_4,,] Y.',
+    'modified'       => 'X [boolean,_1,true,false] [boolean,_2,true,EMPTY STRING] [boolean,_3,EMPTY STRING,false] [boolean,_4,EMPTY STRING,EMPTY STRING] Y.',
+    'all_violations' => {
+        'special' => [],
+        'default' => undef,    # undef means "same as special"
+    },
+    'all_warnings' => {
+        'default' => ['Empty strings as arguments in bracket notation should be avoided'],
+        'special' => undef,
+    },
+    'filter_violations' => undef,    # undef means "same as all_violations"
+    'filter_warnings'   => undef,    # undef means "same as all_warnings"
+    'return_value'      => {
+        'special' => [ -1, 0, 1, 1 ],
+        'default' => undef,             # undef means "same as special"
+    },
+    'get_status_is_warnings' => 1,
+    'diag'                   => 0,
+);
 
 # TODO Complex bare vars (see filter mod for comment specifics)
 #    [output,strong,_2] [output,strong,_-42] [output,strong,_*] [output,strong,_2,Z] [output,strong,_-42,Z] [output,strong,_*,Z] [output,strong,X_2X] [output,strong,X_-42X] [output,strong,X_*X] [output,strong,X_2X,Z] [output,strong,X_-42X,Z] [output,strong,X_*X,Z]

--- a/t/13.phrase_object_precursor_functions.t
+++ b/t/13.phrase_object_precursor_functions.t
@@ -11,7 +11,7 @@ my %bn_cont = (
         'type'  => '_invalid',
     },
     ',' => {
-        'split' => [],
+        'split' => [ '', '' ],
         'type'  => '_invalid',
     },
     ',abc,def' => {


### PR DESCRIPTION
I found that `Locale::Maketext::Utils::Phrase::phrase2struct()` was truncating the list of arguments to complex-type BN expressions when those trailing arguments were empty strings. After discussion of the issue with the maintainer, it was agreed that although using empty strings as arguments was bad style in creating phrases, it was better and easier for the code to parse the expression as written. A warning when any empty string arguments are used is now generated by `Locale::Maketext::Utils::Phrase::Norm::Consider`.